### PR TITLE
Assorted UX improvements

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ archives_base_name=trinkhide
 # Dependencies
 fabric_version=0.92.3+1.20.1
 cca_version=5.2.3
-trinkets_version=3.7.2
+trinkets_version=3.7.1

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -33,7 +33,7 @@ public class TrinkHide implements ModInitializer {
 							.then(Commands
 									.literal("hide")
 									.then(Commands
-											.argument("slot", StringArgumentType.string())
+											.argument("slot", StringArgumentType.greedyString())
 											.executes(ctx -> {
 												var slot = ctx.getArgument("slot", String.class);
 												var player = ctx.getSource().getPlayer();
@@ -61,7 +61,7 @@ public class TrinkHide implements ModInitializer {
 							.then(Commands
 									.literal("show")
 									.then(Commands
-											.argument("slot", StringArgumentType.string())
+											.argument("slot", StringArgumentType.greedyString())
 											.executes(ctx -> {
 												var slot = ctx.getArgument("slot", String.class);
 												var player = ctx.getSource().getPlayer();

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TrinkHide implements ModInitializer {
@@ -92,7 +93,7 @@ public class TrinkHide implements ModInitializer {
 											return 0;
 
 										var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
-										var hiddenSlots = Set.copyOf(component.getHiddenSlots());
+										var hiddenSlots = new HashSet<>(component.getHiddenSlots());
 
 										var groups = TrinketsApi.getPlayerSlots(player)
 											.values()
@@ -112,16 +113,24 @@ public class TrinkHide implements ModInitializer {
 												.toList();
 											if (slots.isEmpty()) continue;
 
-											ctx.getSource().sendSuccess(() -> Component.literal(group.getName() + ":"), false);
+											ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.group", group.getName()), false);
 
 											for (var slot : slots) {
+												var slotName = getSlotName(slot);
 												ctx.getSource().sendSuccess(() -> {
-													var slotName = getSlotName(slot);
-													var message = Component.literal("  " + slotName);
+													var message = Component.translatable("trinkhide.list.slot", slotName);
 													return hiddenSlots.contains(slotName)
 														? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
 														: message;
 												}, false);
+												hiddenSlots.remove(slotName);
+											}
+										}
+
+										if (!hiddenSlots.isEmpty()) {
+											ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.group.invalid_slots").withStyle(ChatFormatting.RED), false);
+											for (var slotName : hiddenSlots.stream().sorted().toList()) {
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.slot", slotName).withStyle(ChatFormatting.RED), false);
 											}
 										}
 

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -1,15 +1,21 @@
 package vg.skye.trinkhide;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
+import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.TrinketsApi;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Set;
 
 public class TrinkHide implements ModInitializer {
 	public static final String MOD_ID = "trinkhide";
@@ -71,7 +77,56 @@ public class TrinkHide implements ModInitializer {
 											})
 									)
 							)
+							.then(Commands
+									.literal("list")
+									.executes(ctx -> {
+										var player = ctx.getSource().getPlayer();
+										if (player == null)
+											return 0;
+
+										var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
+										var hiddenSlots = Set.copyOf(component.getHiddenSlots());
+
+										var groups = TrinketsApi.getPlayerSlots(player)
+											.values()
+											.stream()
+											.sorted(Comparator.comparing(SlotGroup::getName))
+											.toList();
+										if (groups.isEmpty()) {
+											ctx.getSource().sendFailure(Component.translatable("trinkhide.no_slots"));
+											return 1;
+										}
+
+										for (var group : groups) {
+											var slots = group.getSlots()
+												.values()
+												.stream()
+												.sorted(Comparator.comparing(SlotType::getName))
+												.toList();
+											if (slots.isEmpty()) continue;
+
+											ctx.getSource().sendSuccess(() -> Component.literal(group.getName() + ":"), false);
+
+											for (var slot : slots) {
+												ctx.getSource().sendSuccess(() -> {
+													var slotName = getSlotName(slot);
+													var message = Component.literal("  " + slotName);
+													return hiddenSlots.contains(slotName)
+														? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
+														: message;
+												}, false);
+											}
+										}
+
+										return 0;
+									})
+							)
 			);
 		});
+	}
+
+	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not. */
+	public static String getSlotName(SlotType slot) {
+		return slot.getGroup() + "/" + slot.getName();
 	}
 }

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,10 @@ public class TrinkHide implements ModInitializer {
 												var player = ctx.getSource().getPlayer();
 												if (player == null)
 													return 0;
+												if (!validateSlotName(player, slot)) {
+													ctx.getSource().sendFailure(Component.translatable("trinkhide.invalid_slot", slot));
+													return 1;
+												}
 												var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
 												var hiddenSlots = component.getHiddenSlots();
 												if (hiddenSlots.contains(slot)) {
@@ -47,6 +52,7 @@ public class TrinkHide implements ModInitializer {
 												slots.addAll(hiddenSlots);
 												slots.add(slot);
 												component.setHiddenSlots(slots);
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.hidden", slot), false);
 												return 0;
 											})
 									)
@@ -73,6 +79,7 @@ public class TrinkHide implements ModInitializer {
 													slots.add(hiddenSlot);
 												}
 												component.setHiddenSlots(slots);
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.unhidden", slot), false);
 												return 0;
 											})
 									)
@@ -128,5 +135,18 @@ public class TrinkHide implements ModInitializer {
 	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not. */
 	public static String getSlotName(SlotType slot) {
 		return slot.getGroup() + "/" + slot.getName();
+	}
+
+	/** Returns true if this slot name exists for this player. */
+	public static boolean validateSlotName(ServerPlayer player, String slotName) {
+		var parts = slotName.split("/", 2);
+		if (parts.length != 2) return false;
+
+		var groupKey = parts[0];
+		var slotKey = parts[1];
+
+		var groups = TrinketsApi.getPlayerSlots(player);
+		var group = groups.get(groupKey);
+		return group != null && group.getSlots().containsKey(slotKey);
 	}
 }

--- a/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
+++ b/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vg.skye.trinkhide.TrinkHide;
 import vg.skye.trinkhide.TrinkHideComponents;
 
 @Mixin(TrinketFeatureRenderer.class)
@@ -18,7 +19,7 @@ public class TrinketFeatureRendererMixin {
     @Inject(method = "lambda$render$0", at = @At("HEAD"), cancellable = true)
     private void skipRender(PoseStack matrices, ItemStack stack, SlotReference slotReference, MultiBufferSource vertexConsumers, int light, LivingEntity entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch, TrinketRenderer renderer, CallbackInfo ci) {
         var slot = slotReference.inventory().getSlotType();
-        var name = slot.getGroup() + "/" + slot.getName();
+        var name = TrinkHide.getSlotName(slot);
         var component = TrinkHideComponents.HIDDEN_TRINKETS.getNullable(entity);
         if (component != null && component.getHiddenSlots().contains(name)) {
             ci.cancel();

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -1,4 +1,5 @@
 {
   "trinkhide.already_hidden": "Slot was already hidden!",
-  "trinkhide.not_hidden": "Slot was already unhidden!"
+  "trinkhide.not_hidden": "Slot was already unhidden!",
+  "trinkhide.no_slots": "No slots found!"
 }

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -1,5 +1,8 @@
 {
   "trinkhide.already_hidden": "Slot was already hidden!",
+  "trinkhide.hidden": "Slot is now hidden: %s",
   "trinkhide.not_hidden": "Slot was already unhidden!",
-  "trinkhide.no_slots": "No slots found!"
+  "trinkhide.unhidden": "Slot is now visible: %s",
+  "trinkhide.no_slots": "No slots found!",
+  "trinkhide.invalid_slot": "Invalid slot: %s"
 }

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -4,5 +4,8 @@
   "trinkhide.not_hidden": "Slot was already unhidden!",
   "trinkhide.unhidden": "Slot is now visible: %s",
   "trinkhide.no_slots": "No slots found!",
-  "trinkhide.invalid_slot": "Invalid slot: %s"
+  "trinkhide.invalid_slot": "Invalid slot: %s",
+  "trinkhide.list.group": "%s:",
+  "trinkhide.list.group.invalid_slots": "Invalid hidden slots:",
+  "trinkhide.list.slot": "  %s"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
 		"minecraft": "~1.20.1",
 		"java": ">=17",
 		"fabric-api": "*",
-		"trinkets": "~3.7.2",
+		"trinkets": "~3.7.1",
 		"cardinal-components-entity": "~5.2.2"
 	},
 	"custom": {


### PR DESCRIPTION
Changes:
* Added `/trinkhide list` to list all valid slot names, so players don't have to guess. It also shows which slots are currently hidden by graying them out and italicizing them.
* Added confirmation messages when slots are hidden/shown successfully.
* Added slot name validation to `/trinkhide hide`, so invalid slot names print an error instead of silently hiding a slot that doesn't actually exist.
* Changed the argument type for `/trinkhide hide` and `/trinkhide show` from string to greedyString so slot names don't need to be quoted.
* Downgraded the Trinkets dependency to 3.7.1 as a workaround for https://github.com/emilyploszaj/trinkets/issues/367, so the dev environment actually works now.

I tested all of these changes both in the dev environment and in the HexxyTest :3 modpack.