### PR TITLE
Add support for indexed slots

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,4 +15,4 @@ archives_base_name=trinkhide
 # Dependencies
 fabric_version=0.92.3+1.20.1
 cca_version=5.2.3
-trinkets_version=3.7.2
+trinkets_version=3.7.1

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -2,6 +2,7 @@ package vg.skye.trinkhide;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
 import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.api.SlotReference;
 import dev.emi.trinkets.api.SlotType;
 import dev.emi.trinkets.api.TrinketsApi;
 import net.fabricmc.api.ModInitializer;
@@ -17,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
-import java.util.Set;
 
 public class TrinkHide implements ModInitializer {
 	public static final String MOD_ID = "trinkhide";
@@ -116,14 +116,16 @@ public class TrinkHide implements ModInitializer {
 											ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.group", group.getName()), false);
 
 											for (var slot : slots) {
-												var slotName = getSlotName(slot);
-												ctx.getSource().sendSuccess(() -> {
-													var message = Component.translatable("trinkhide.list.slot", slotName);
-													return hiddenSlots.contains(slotName)
-														? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
-														: message;
-												}, false);
-												hiddenSlots.remove(slotName);
+												for (var index = 0; index < slot.getAmount(); index++) {
+													var slotName = getSlotName(slot, index);
+													ctx.getSource().sendSuccess(() -> {
+														var message = Component.translatable("trinkhide.list.slot", slotName);
+														return hiddenSlots.contains(slotName)
+															? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
+															: message;
+													}, false);
+													hiddenSlots.remove(slotName);
+												}
 											}
 										}
 
@@ -142,20 +144,53 @@ public class TrinkHide implements ModInitializer {
 	}
 
 	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not. */
-	public static String getSlotName(SlotType slot) {
-		return slot.getGroup() + "/" + slot.getName();
+	public static String getSlotName(SlotReference slot) {
+		return getSlotName(slot.inventory().getSlotType(), slot.index());
+	}
+
+	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not.
+	 *  If the slot amount is 1, the index will not be used.
+	 *  <p>
+	 *  Format: `group/slot` (eg. `head/hat`) or `group/slot/index` (eg. `head/face/0`)
+	 *  <p>
+	 *  Throws IllegalArgumentException if the index is out of range for this slot.
+	 * */
+	public static String getSlotName(SlotType slot, int index) throws IllegalArgumentException {
+		if (index < 0 || index >= slot.getAmount()) {
+			throw new IllegalArgumentException("Slot index out of range: " + index);
+		}
+		var name = slot.getGroup() + "/" + slot.getName();
+		return slot.getAmount() > 1
+			? name + "/" + index
+			: name;
 	}
 
 	/** Returns true if this slot name exists for this player. */
 	public static boolean validateSlotName(ServerPlayer player, String slotName) {
-		var parts = slotName.split("/", 2);
-		if (parts.length != 2) return false;
+		// note: this will fail if someone adds a trinket slot like "foo/bar/baz", but based on the trinkets source code I don't think that's supported?
+		var parts = slotName.split("/", 3);
+		if (parts.length < 2) return false;
 
-		var groupKey = parts[0];
-		var slotKey = parts[1];
+		var group = TrinketsApi.getPlayerSlots(player).get(parts[0]);
+		if (group == null) return false;
 
-		var groups = TrinketsApi.getPlayerSlots(player);
-		var group = groups.get(groupKey);
-		return group != null && group.getSlots().containsKey(slotKey);
+		var slot = group.getSlots().get(parts[1]);
+		if (slot == null) return false;
+
+		if (slot.getAmount() > 1) {
+			if (parts.length < 3) return false;
+
+			int index;
+			try {
+				index = Integer.parseInt(parts[2]);
+			} catch (NumberFormatException e) {
+				return false;
+			}
+
+			return index >= 0 && index < slot.getAmount();
+		} else {
+			// slots with amount == 1 don't have the index in their name
+			return parts.length == 2;
+		}
 	}
 }

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -33,7 +33,7 @@ public class TrinkHide implements ModInitializer {
 							.then(Commands
 									.literal("hide")
 									.then(Commands
-											.argument("slot", StringArgumentType.string())
+											.argument("slot", StringArgumentType.greedyString())
 											.executes(ctx -> {
 												var slot = ctx.getArgument("slot", String.class);
 												var player = ctx.getSource().getPlayer();
@@ -61,7 +61,7 @@ public class TrinkHide implements ModInitializer {
 							.then(Commands
 									.literal("show")
 									.then(Commands
-											.argument("slot", StringArgumentType.string())
+											.argument("slot", StringArgumentType.greedyString())
 											.executes(ctx -> {
 												var slot = ctx.getArgument("slot", String.class);
 												var player = ctx.getSource().getPlayer();

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.Set;
 
 public class TrinkHide implements ModInitializer {
@@ -92,7 +93,7 @@ public class TrinkHide implements ModInitializer {
 											return 0;
 
 										var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
-										var hiddenSlots = Set.copyOf(component.getHiddenSlots());
+										var hiddenSlots = new HashSet<>(component.getHiddenSlots());
 
 										var groups = TrinketsApi.getPlayerSlots(player)
 											.values()
@@ -112,16 +113,24 @@ public class TrinkHide implements ModInitializer {
 												.toList();
 											if (slots.isEmpty()) continue;
 
-											ctx.getSource().sendSuccess(() -> Component.literal(group.getName() + ":"), false);
+											ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.group", group.getName()), false);
 
 											for (var slot : slots) {
+												var slotName = getSlotName(slot);
 												ctx.getSource().sendSuccess(() -> {
-													var slotName = getSlotName(slot);
-													var message = Component.literal("  " + slotName);
+													var message = Component.translatable("trinkhide.list.slot", slotName);
 													return hiddenSlots.contains(slotName)
 														? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
 														: message;
 												}, false);
+												hiddenSlots.remove(slotName);
+											}
+										}
+
+										if (!hiddenSlots.isEmpty()) {
+											ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.group.invalid_slots").withStyle(ChatFormatting.RED), false);
+											for (var slotName : hiddenSlots.stream().sorted().toList()) {
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.list.slot", slotName).withStyle(ChatFormatting.RED), false);
 											}
 										}
 

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -1,15 +1,21 @@
 package vg.skye.trinkhide;
 
 import com.mojang.brigadier.arguments.StringArgumentType;
+import dev.emi.trinkets.api.SlotGroup;
+import dev.emi.trinkets.api.SlotType;
+import dev.emi.trinkets.api.TrinketsApi;
 import net.fabricmc.api.ModInitializer;
 
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
+import net.minecraft.ChatFormatting;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Set;
 
 public class TrinkHide implements ModInitializer {
 	public static final String MOD_ID = "trinkhide";
@@ -71,7 +77,56 @@ public class TrinkHide implements ModInitializer {
 											})
 									)
 							)
+							.then(Commands
+									.literal("list")
+									.executes(ctx -> {
+										var player = ctx.getSource().getPlayer();
+										if (player == null)
+											return 0;
+
+										var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
+										var hiddenSlots = Set.copyOf(component.getHiddenSlots());
+
+										var groups = TrinketsApi.getPlayerSlots(player)
+											.values()
+											.stream()
+											.sorted(Comparator.comparing(SlotGroup::getName))
+											.toList();
+										if (groups.isEmpty()) {
+											ctx.getSource().sendFailure(Component.translatable("trinkhide.no_slots"));
+											return 1;
+										}
+
+										for (var group : groups) {
+											var slots = group.getSlots()
+												.values()
+												.stream()
+												.sorted(Comparator.comparing(SlotType::getName))
+												.toList();
+											if (slots.isEmpty()) continue;
+
+											ctx.getSource().sendSuccess(() -> Component.literal(group.getName() + ":"), false);
+
+											for (var slot : slots) {
+												ctx.getSource().sendSuccess(() -> {
+													var slotName = getSlotName(slot);
+													var message = Component.literal("  " + slotName);
+													return hiddenSlots.contains(slotName)
+														? message.withStyle(ChatFormatting.DARK_GRAY, ChatFormatting.ITALIC)
+														: message;
+												}, false);
+											}
+										}
+
+										return 0;
+									})
+							)
 			);
 		});
+	}
+
+	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not. */
+	public static String getSlotName(SlotType slot) {
+		return slot.getGroup() + "/" + slot.getName();
 	}
 }

--- a/src/main/java/vg/skye/trinkhide/TrinkHide.java
+++ b/src/main/java/vg/skye/trinkhide/TrinkHide.java
@@ -10,6 +10,7 @@ import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.minecraft.ChatFormatting;
 import net.minecraft.commands.Commands;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,6 +38,10 @@ public class TrinkHide implements ModInitializer {
 												var player = ctx.getSource().getPlayer();
 												if (player == null)
 													return 0;
+												if (!validateSlotName(player, slot)) {
+													ctx.getSource().sendFailure(Component.translatable("trinkhide.invalid_slot", slot));
+													return 1;
+												}
 												var component = TrinkHideComponents.HIDDEN_TRINKETS.get(player);
 												var hiddenSlots = component.getHiddenSlots();
 												if (hiddenSlots.contains(slot)) {
@@ -47,6 +52,7 @@ public class TrinkHide implements ModInitializer {
 												slots.addAll(hiddenSlots);
 												slots.add(slot);
 												component.setHiddenSlots(slots);
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.hidden", slot), false);
 												return 0;
 											})
 									)
@@ -73,6 +79,7 @@ public class TrinkHide implements ModInitializer {
 													slots.add(hiddenSlot);
 												}
 												component.setHiddenSlots(slots);
+												ctx.getSource().sendSuccess(() -> Component.translatable("trinkhide.unhidden", slot), false);
 												return 0;
 											})
 									)
@@ -128,5 +135,18 @@ public class TrinkHide implements ModInitializer {
 	/** Returns the slot name used by TrinkHide to determine if a slot should be rendered or not. */
 	public static String getSlotName(SlotType slot) {
 		return slot.getGroup() + "/" + slot.getName();
+	}
+
+	/** Returns true if this slot name exists for this player. */
+	public static boolean validateSlotName(ServerPlayer player, String slotName) {
+		var parts = slotName.split("/", 2);
+		if (parts.length != 2) return false;
+
+		var groupKey = parts[0];
+		var slotKey = parts[1];
+
+		var groups = TrinketsApi.getPlayerSlots(player);
+		var group = groups.get(groupKey);
+		return group != null && group.getSlots().containsKey(slotKey);
 	}
 }

--- a/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
+++ b/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
@@ -11,6 +11,7 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import vg.skye.trinkhide.TrinkHide;
 import vg.skye.trinkhide.TrinkHideComponents;
 
 @Mixin(TrinketFeatureRenderer.class)
@@ -18,7 +19,7 @@ public class TrinketFeatureRendererMixin {
     @Inject(method = "lambda$render$0", at = @At("HEAD"), cancellable = true)
     private void skipRender(PoseStack matrices, ItemStack stack, SlotReference slotReference, MultiBufferSource vertexConsumers, int light, LivingEntity entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch, TrinketRenderer renderer, CallbackInfo ci) {
         var slot = slotReference.inventory().getSlotType();
-        var name = slot.getGroup() + "/" + slot.getName();
+        var name = TrinkHide.getSlotName(slot);
         var component = TrinkHideComponents.HIDDEN_TRINKETS.getNullable(entity);
         if (component != null && component.getHiddenSlots().contains(name)) {
             ci.cancel();

--- a/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
+++ b/src/main/java/vg/skye/trinkhide/mixin/TrinketFeatureRendererMixin.java
@@ -18,8 +18,7 @@ import vg.skye.trinkhide.TrinkHideComponents;
 public class TrinketFeatureRendererMixin {
     @Inject(method = "lambda$render$0", at = @At("HEAD"), cancellable = true)
     private void skipRender(PoseStack matrices, ItemStack stack, SlotReference slotReference, MultiBufferSource vertexConsumers, int light, LivingEntity entity, float limbAngle, float limbDistance, float tickDelta, float animationProgress, float headYaw, float headPitch, TrinketRenderer renderer, CallbackInfo ci) {
-        var slot = slotReference.inventory().getSlotType();
-        var name = TrinkHide.getSlotName(slot);
+        var name = TrinkHide.getSlotName(slotReference);
         var component = TrinkHideComponents.HIDDEN_TRINKETS.getNullable(entity);
         if (component != null && component.getHiddenSlots().contains(name)) {
             ci.cancel();

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -1,4 +1,5 @@
 {
   "trinkhide.already_hidden": "Slot was already hidden!",
-  "trinkhide.not_hidden": "Slot was already unhidden!"
+  "trinkhide.not_hidden": "Slot was already unhidden!",
+  "trinkhide.no_slots": "No slots found!"
 }

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -1,5 +1,8 @@
 {
   "trinkhide.already_hidden": "Slot was already hidden!",
+  "trinkhide.hidden": "Slot is now hidden: %s",
   "trinkhide.not_hidden": "Slot was already unhidden!",
-  "trinkhide.no_slots": "No slots found!"
+  "trinkhide.unhidden": "Slot is now visible: %s",
+  "trinkhide.no_slots": "No slots found!",
+  "trinkhide.invalid_slot": "Invalid slot: %s"
 }

--- a/src/main/resources/assets/trinkhide/lang/en_us.json
+++ b/src/main/resources/assets/trinkhide/lang/en_us.json
@@ -4,5 +4,8 @@
   "trinkhide.not_hidden": "Slot was already unhidden!",
   "trinkhide.unhidden": "Slot is now visible: %s",
   "trinkhide.no_slots": "No slots found!",
-  "trinkhide.invalid_slot": "Invalid slot: %s"
+  "trinkhide.invalid_slot": "Invalid slot: %s",
+  "trinkhide.list.group": "%s:",
+  "trinkhide.list.group.invalid_slots": "Invalid hidden slots:",
+  "trinkhide.list.slot": "  %s"
 }

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -29,7 +29,7 @@
 		"minecraft": "~1.20.1",
 		"java": ">=17",
 		"fabric-api": "*",
-		"trinkets": "~3.7.2",
+		"trinkets": "~3.7.1",
 		"cardinal-components-entity": "~5.2.2"
 	},
 	"custom": {


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a8afa92b-c23f-4b4a-88cd-e9f3e72a62df)

This PR changes the slot name format used by TrinkHide for slots where amount > 1. Those slot names are now in the format `group/slot/index`, eg. `head/face/0`. Slots with amount == 1 are unchanged.

Depends on #1.

I put this in a separate PR because it changes actual functionality and will make previously hidden slots invalid. This won't break anything, but people will need to re-run `/trinkhide hide` for any slots they hid that now have an index in the name, and the old slot name will be listed as invalid until they unhide it.
